### PR TITLE
Fixing foreign tags in "Oxen of the Sun"

### DIFF
--- a/u14_oxen.xml
+++ b/u14_oxen.xml
@@ -1,5 +1,5 @@
 <div type="episode" n="14">
-<p rend="non-indent"><lb n="140001"/>Deshil Holles Eamus. Deshil Holles Eamus. Deshil Holles Eamus.</p>
+<p rend="non-indent"><lb n="140001"/><foreign xml:lang="ga">Deshil</foreign> Holles <foreign xml:lang="la">Eamus</foreign>. <foreign xml:lang="ga">Deshil</foreign> Holles <foreign xml:lang="la">Eamus</foreign>. <foreign xml:lang="ga">Deshil</foreign> Holles <foreign xml:lang="la">Eamus</foreign>.
 <p rend="non-indent"><lb n="140002"/>Send us bright one, light one, Horhorn, quickening and wombfruit. Send
 <lb n="140003"/>us bright one, light one, Horhorn, quickening and wombfruit. Send us
 <lb n="140004"/>bright one, light one, Horhorn, quickening and wombfruit.</p>
@@ -305,7 +305,7 @@
 <lb n="140304"/>in the one denial or ignorancy with Peter Piscator who lives in the house
 <lb n="140305"/>that Jack built and with Joseph the joiner patron of the happy demise of all
 <lb n="140306"/>unhappy marriages, <foreign xml:lang="fr">parceque M. Léo Taxil nous a dit que qui l'avait mise
-<lb n="140307"/>dans cette fichue position c'était le sacré pigeon, ventre de Dieu! Entweder</foreign>
+<lb n="140307"/>dans cette fichue position c'était le sacré pigeon, ventre de Dieu!</foreign> <foreign xml:lang="de">Entweder</foreign>
 <lb n="140308"/>transubstantiality <foreign xml:lang="de">oder</foreign> consubstantiality but in no case subsubstantiality.
 <lb n="140309"/>And all cried out upon it for a very scurvy word. A pregnancy without joy,
 <lb n="140310"/>he said, a birth without pangs, a body without blemish, a belly without
@@ -505,7 +505,7 @@
 <lb n="140504"/>to Horne's. There Leop. Bloom of Crawford's journal sitting snug with a
 <lb n="140505"/>covey of wags, likely brangling fellows, Dixon jun., scholar of my lady of
 <lb n="140506"/>Mercy's, Vin. Lynch, a Scots fellow, Will. Madden, T. Lenehan, very sad
-<lb n="140507"/>about a racer he fancied and Stephen D. Leop. Bloom there for a languor
+<lb n="140507"/>about a racer he fancied and Stephen D. Leop. Bloom there for a languor
 <lb n="140508"/>he had but was now better, he having dreamed tonight a strange fancy of
 <lb n="140509"/>his dame Mrs Moll with red slippers on in a pair of Turkey trunks which is
 <lb n="140510"/>thought by those in ken to be for a change and Mistress Purefoy there, that
@@ -1022,7 +1022,7 @@
 <lb n="141021"/>me the like of a soulth or a bullawurrus? My hell, and Ireland's, is in this
 <lb n="141022"/>life. It is what I tried to obliterate my crime. Distractions, rookshooting, the
 <lb n="141023"/>Erse language (he recited some), laudanum (he raised the phial to his lips),
-<lb n="141024"/>camping out. In vain! His spectre stalks me. Dope is my only hope .... Ah!
+<lb n="141024"/>camping out. In vain! His spectre stalks me. Dope is my only hope... Ah!
 <lb n="141025"/>Destruction! The black panther! With a cry he suddenly vanished and the
 <lb n="141026"/>panel slid back. An instant later his head appeared in the door opposite and
 <lb n="141027"/>said: Meet me at Westland Row station at ten past eleven. He was gone.
@@ -1053,7 +1053,7 @@
 <lb n="141052"/>his case of bright trinketware (alas! a thing now of the past!) and a
 <lb n="141053"/>quiverful of compliant smiles for this or that halfwon housewife reckoning
 <lb n="141054"/>it out upon her fingertips or for a budding virgin, shyly acknowledging (but
-<lb n="141055"/>the heart? tell me!) his studied baisemoins. The scent, the smile, but, more
+<lb n="141055"/>the heart? tell me!) his studied <foreign xml:lang="fr">baisemoins</foreign>. The scent, the smile, but, more
 <lb n="141056"/>than these, the dark eyes and oleaginous address, brought home at duskfall
 <lb n="141057"/>many a commission to the head of the firm, seated with Jacob's pipe after
 <lb n="141058"/>like labours in the paternal ingle (a meal of noodles, you may be sure, is
@@ -1300,8 +1300,8 @@
 <lb n="141299"/>cookable and eatable flesh of a calf newly dropped from its mother. In a
 <lb n="141300"/>recent public controversy with Mr L. Bloom (Pubb. Canv.) which took
 <lb n="141301"/>place in the commons' hall of the National Maternity Hospital, 29, 30 and
-<lb n="141302"/>31 Holles street, of which, as is well known, Dr A. Horne (Lic. in Midw.,
-<lb n="141303"/>F. K. Q. C. P. I.) is the able and popular master, he is reported by
+<lb n="141302"/>31 Holles street, of which, as is well known, Dr A. Horne (Lic. in Midw.,
+<lb n="141303"/>F.K.Q.C.P.I.) is the able and popular master, he is reported by
 <lb n="141304"/>eyewitnesses as having stated that once a woman has let the cat into the bag
 <lb n="141305"/>(an esthete's allusion, presumably, to one of the most complicated and
 <lb n="141306"/>marvellous of all nature's processes – the act of sexual congress) she must
@@ -1481,7 +1481,7 @@
 <lb n="141480"/>allbeplastered neck you stole my heart, O gluepot. Sir? Spud again the
 <lb n="141481"/>rheumatiz? All poppycock, you'll scuse me saying. For the hoi polloi. I vear
 <lb n="141482"/>thee beest a gert vool. Well, doc? Back fro Lapland? Your corporosity
-<lb n="141483"/>sagaciating O K? How's the squaws and papooses? Womanbody after
+<lb n="141483"/>sagaciating OK? How's the squaws and papooses? Womanbody after
 <lb n="141484"/>going on the straw? Stand and deliver. Password. There's hair. Ours the
 <lb n="141485"/>white death and the ruddy birth. Hi! Spit in your own eye, boss!
 <lb n="141486"/>Mummer's wire. Cribbed out of Meredith. Jesified, orchidised, polycimical
@@ -1504,7 +1504,7 @@
 <lb n="141503"/>bar and a wing. You larn that go off of they there Frenchy bilks? Won't
 <lb n="141504"/>wash here for nuts nohow. Lil chile velly solly. Ise de cutest colour coon
 <lb n="141505"/>down our side. Gawds teruth, Chawley. We are nae fou. We're nae tha fou.
-<lb n="141506"/>Au reservoir, mossoo. Tanks you.</p>
+<lb n="141506"/><foreign xml:lang="franglais">Au reservoir, mossoo. Tanks you.</foreign></p>
 <p><lb n="141507"/>'Tis, sure. What say? In the speakeasy. Tight. I shee you, shir.
 <lb n="141508"/>Bantam, two days teetee. Bowsing nowt but claretwine. Garn! Have a glint,
 <lb n="141509"/>do. Gum, I'm jiggered. And been to barber he have. Too full for words.


### PR DESCRIPTION
This adds and fixes a few <foreign> tags in Oxen of the Sun.

There are also a few invisible non-breaking space ASCII characters removed.

To easily find non-breaking spaces, you can put the following in your `.vimrc`, and they'll all show up as tiny skulls:

```
set listchars=nbsp:☠,tab:▸␣
```
