### PR TITLE
Add cross reference from Oxen of the Sun to Wandering Rocks.

### DIFF
--- a/u10_wandering_rocks.xml
+++ b/u10_wandering_rocks.xml
@@ -200,7 +200,7 @@
 <p><lb n="100199"/>A flushed young man came from a gap of a hedge and after him came
 <lb n="100200"/>a young woman with wild nodding daisies in her hand. The young man
 <lb n="100201"/>raised his cap abruptly: the young woman abruptly bent and with slow care
-<lb n="100202"/>detached from her light skirt a clinging twig.</p>
+<lb n="100202" xml:id="lb_100202"/>detached from her light skirt a clinging twig.</p>
 <p><lb n="100203"/>Father Conmee blessed both gravely and turned a thin page of his
 <lb n="100204"/>breviary. <foreign xml:lang="he">Sin</foreign>:
 <lb n="100205"/><said who="jc">―<foreign xml:lang="la">Principes persecuti sunt me gratis: et a verbis tuis formidavit cor meum.</foreign></said></p>

--- a/u14_oxen.xml
+++ b/u14_oxen.xml
@@ -1156,8 +1156,8 @@
 <lb n="141155"/>He was walking by the hedge, reading, I think a brevier book with, I doubt
 <lb n="141156"/>not, a witty letter in it from Glycera or Chloe to keep the page. The sweet
 <lb n="141157"/>creature turned all colours in her confusion, feigning to reprove a slight
-<lb n="141158"/>disorder in her dress: a slip of underwood clung there for the very trees
-<lb n="141159"/>adore her. When Conmee had passed she glanced at her lovely echo in that
+<lb n="141158"/>disorder in her dress: <ref target="u10_wandering_rocks.xml#lb_100202">a slip of underwood clung there for the very trees
+<lb n="141159"/>adore her.</ref> When Conmee had passed she glanced at her lovely echo in that
 <lb n="141160"/>little mirror she carries. But he had been kind. In going by he had blessed
 <lb n="141161"/>us. The gods too are ever kind, Lenehan said. If I had poor luck with Bass's
 <lb n="141162"/>mare perhaps this draught of his may serve me more propensely. He was


### PR DESCRIPTION
This adds a brief demonstration of how events in the text might be cross-referenced, following TEI:
* [`<ref>` tag spec](http://www.tei-c.org/release/doc/tei-p5-doc/en/html/ref-ref.html)
* [Section 16.2: Pointing Mechanisms](http://www.tei-c.org/release/doc/tei-p5-doc/en/html/SA.html#SAXP)

In Oxen of the Sun, Vincent recounts an encounter with Father Conmee
that occurred in Wandering Rocks. The cross-reference from
Oxen looks like this:

```
<ref target="u10_wandering_rocks.xml#lb_100202">a slip of underwood
```

This links to an `<lb>` tag in Wandering Rocks, modified to have an `xml:id`:

```
<lb n="100202" xml:id="lb_100202"/>detached from her light skirt a clinging twig.</p>
```

This keeps the amount of text inside the `<ref>` tag fairly limited.