### PR TITLE
Repairing xml:id tags

### DIFF
--- a/u01_telemachus.xml
+++ b/u01_telemachus.xml
@@ -670,7 +670,7 @@
 <lb n="010668"/>our national problem, I'm afraid, just now.</said></p>
 <p><lb n="010669"/>Two men stood at the verge of the cliff, watching: businessman,
 <lb n="010670"/>boatman.
-<lb n="010671"/><said xml:id="010671_unclear" who="ubus">―She's making for Bullock harbour.<certainty target="#010671_unclear" match="@who" locus="value" assertedValue="uboat" degree="0.5"> <desc>It's unclear whether the businessman or the boatman speaks.</desc></certainty></said></p>
+<lb n="010671"/><said xml:id="said_010671_unclear" who="ubus">―She's making for Bullock harbour.<certainty target="#said_010671_unclear" match="@who" locus="value" assertedValue="uboat" degree="0.5"> <desc>It's unclear whether the businessman or the boatman speaks.</desc></certainty></said></p>
 <p><lb n="010672"/>The boatman nodded towards the north of the bay with some disdain.
 <lb n="010673"/><said who="uboat">―There's five fathoms out there,</said> he said. <said who="uboat">It'll be swept up that way when
 <lb n="010674"/>the tide comes in about one. It's nine days today.</said></p>

--- a/u06_hades.xml
+++ b/u06_hades.xml
@@ -2,7 +2,7 @@
 <p><lb n="060001"/>Martin Cunningham, first, poked his silkhatted head into the creaking
 <lb n="060002"/>carriage and, entering deftly, seated himself. Mr Power stepped in after him,
 <lb n="060003"/>curving his height with care.
-<lb n="060004"/><said xml:id="060004_unclear" who="mc">―Come on, Simon.<certainty target="#060004_unclear" match="@who" locus="value" assertedValue="jp" degree="0.5"><desc>It's unclear whether Cunningham or Power speaks.</desc></certainty></said>
+<lb n="060004"/><said xml:id="said_060004_unclear" who="mc">―Come on, Simon.<certainty target="#said_060004_unclear" match="@who" locus="value" assertedValue="jp" degree="0.5"><desc>It's unclear whether Cunningham or Power speaks.</desc></certainty></said>
 <lb n="060005"/><said who="lb">―After you,</said> Mr Bloom said.</p>
 <p><lb n="060006"/>Mr Dedalus covered himself quickly and got in, saying:
 <lb n="060007"/><said who="sid">―Yes, yes.</said>


### PR DESCRIPTION
This resolves a validity error when running xmllint with the DTD schema.
When the xml:id attribute begins with a number, this raises the error:

```
validity error : xml:id : attribute value 010671_unclear is not an NCName
```

This fixes the issue by prefixing the attribute value with the name of
the tag the `xml:id` modifies.