### PR TITLE
Adding first cross references.

### DIFF
--- a/cross-references.xml
+++ b/cross-references.xml
@@ -1,0 +1,8 @@
+<TEI xmlns:xi="http://www.w3.org/2003/XInclude">
+    <link xml:id="agenbite" target="u01_telemachus.xml#lb_010481_agenbite u09_scylla.xml#lb_090196_agenbite u09_scylla.xml#lb_090809 u10_wandering_rocks.xml#lb_100875 u10_wandering_rocks.xml#lb_100879"/>
+    <note>
+        Agenbite of inwit: Middle English for, "again bites the inner wit" (referring to the guilt of conscience). 
+        Also the title of a confessional prose work written in a Kentish dialect of Middle English.
+        <ref target="https://en.wikipedia.org/wiki/Ayenbite_of_Inwyt"></ref>
+    </note>
+</TEI>

--- a/cross-references.xml
+++ b/cross-references.xml
@@ -5,4 +5,6 @@
         Also the title of a confessional prose work written in a Kentish dialect of Middle English.
         <ref target="https://en.wikipedia.org/wiki/Ayenbite_of_Inwyt"></ref>
     </note>
+    <link xml:id="twig-skirt" target="u10_wandering_rocks.xml#lb_100201 u10_wandering_rocks.xml#lb_100440 u14_oxen.xml#lb_141158"/>
+    <link xml:id="lemon-soap" target="u05_lotus-eaters.xml#lb_050513 u17_ithaca.xml#lb_170232"/>
 </TEI>

--- a/cross-references.xml
+++ b/cross-references.xml
@@ -1,6 +1,6 @@
 <TEI xmlns:xi="http://www.w3.org/2003/XInclude">
     <link xml:id="agenbite" target="u01_telemachus.xml#lb_010481_agenbite u09_scylla.xml#lb_090196_agenbite u09_scylla.xml#lb_090809 u10_wandering_rocks.xml#lb_100875 u10_wandering_rocks.xml#lb_100879"/>
-    <note>
+    <note target="agenbite">
         Agenbite of inwit: Middle English for, "again bites the inner wit" (referring to the guilt of conscience). 
         Also the title of a confessional prose work written in a Kentish dialect of Middle English.
         <ref target="https://en.wikipedia.org/wiki/Ayenbite_of_Inwyt"></ref>

--- a/u01_telemachus.xml
+++ b/u01_telemachus.xml
@@ -480,7 +480,7 @@
 <p><lb n="010478"/>Haines from the corner where he was knotting easily a scarf about
 <lb n="010479"/>the loose collar of his tennis shirt spoke:
 <lb n="010480"/><said who="ha">―I intend to make a collection of your sayings if you will let me.</said></p>
-<p><lb n="010481"/>Speaking to me. They wash and tub and scrub. Agenbite of inwit.
+<p><lb n="010481"/>Speaking to me. They wash and tub and scrub. <ref xml:id="lb_010481">Agenbite of inwit.</ref>
 <lb n="010482"/>Conscience. Yet here's a spot.
 <lb n="010483"/><said who="ha">―That one about the cracked lookingglass of a servant being the symbol of
 <lb n="010484"/>Irish art is deuced good.</said></p>

--- a/u05_lotus-eaters.xml
+++ b/u05_lotus-eaters.xml
@@ -511,7 +511,7 @@
 <lb n="050510"/>take one of these soaps. How much are they?</said>
 <lb n="050511"/><said who="fws">―Fourpence, sir.</said></p>
 <p><lb n="050512"/>Mr Bloom raised a cake to his nostrils. Sweet lemony wax.
-<lb n="050513"/><said who="lb">―I'll take this one,</said> he said. <said who="lb">That makes three and a penny.</said>
+<lb n="050513"/><ref xml:id="lb_050513"><said who="lb">―I'll take this one,</said> he said. <said who="lb">That makes three and a penny.</said></ref>
 <lb n="050514"/><said who="fws">―Yes, sir,</said> the chemist said. <said who="fws">You can pay all together, sir, when you come
 <lb n="050515"/>back.</said>
 <lb n="050516"/><said who="lb">―Good,</said> Mr Bloom said.</p>

--- a/u09_scylla.xml
+++ b/u09_scylla.xml
@@ -194,7 +194,7 @@
 <p><lb n="090193"/>Marry, I wanted it.</p>
 <p><lb n="090194"/>Take thou this noble.</p>
 <p><lb n="090195"/>Go to! You spent most of it in Georgina Johnson's bed, clergyman's
-<lb n="090196"/>daughter. Agenbite of inwit.</p>
+<lb n="090196"/>daughter. <ref xml:id="lb_090196">Agenbite of inwit.</ref></p>
 <p><lb n="090197"/>Do you intend to pay it back?</p>
 <p><lb n="090198"/>O, yes.</p>
 <p><lb n="090199"/>When? Now?</p>
@@ -807,7 +807,7 @@
 <lb n="090806"/>chapbooks preferring them to the <title type="play">Merry Wives</title> and, loosing her nightly
 <lb n="090807"/>waters on the jordan, she thought over <title type="book">Hooks and Eyes for Believers'
 <lb n="090808"/>Breeches</title> and <title type="book">The Most Spiritual Snuffbox to Make the Most Devout Souls
-<lb n="090809"/>Sneeze</title>. Venus has twisted her lips in prayer. Agenbite of inwit: remorse of
+<lb n="090809"/>Sneeze</title>. Venus has twisted her lips in prayer. <ref xml:id="lb_090809">Agenbite of inwit</ref>: remorse of
 <lb n="090810"/>conscience. It is an age of exhausted whoredom groping for its god.</said>
 <lb n="090811"/><said who="je">―History shows that to be true,</said> <foreign xml:lang="la">inquit Eglintonus Chronolologos</foreign>. <said who="je">The ages
 <lb n="090812"/>succeed one another. But we have it on high authority that a man's worst

--- a/u10_wandering_rocks.xml
+++ b/u10_wandering_rocks.xml
@@ -873,11 +873,11 @@
 <lb n="100872"/><said who="sd">―Here,</said> Stephen said. <said who="sd">It's all right. Mind Maggy doesn't pawn it on you. I
 <lb n="100873"/>suppose all my books are gone.</said>
 <lb n="100874"/><said who="did">―Some,</said> Dilly said. <said who="did">We had to.</said></p>
-<p><lb n="100875"/>She is drowning. Agenbite. Save her. Agenbite. All against us. She will
+<p><lb n="100875"/>She is drowning. <ref xml:id="lb_100875">Agenbite. Save her. Agenbite.</ref> All against us. She will
 <lb n="100876"/>drown me with her, eyes and hair. Lank coils of seaweed hair around me,
 <lb n="100877"/>my heart, my soul. Salt green death.</p>
 <p><lb n="100878"/>We.</p>
-<p><lb n="100879"/>Agenbite of inwit. Inwit's agenbite.</p>
+<p><lb n="100879"/><ref xml:id="lb_100879">Agenbite of inwit. Inwit's agenbite.</ref></p>
 <p><lb n="100880"/>Misery! Misery!</p>
 <lb n="100881"/><trailer>* * *</trailer></div>
 <div type="section" n="14"><p><lb n="100882"/><said who="fc">―Hello, Simon,</said> Father Cowley said. <said who="fc">How are things?</said>

--- a/u10_wandering_rocks.xml
+++ b/u10_wandering_rocks.xml
@@ -199,8 +199,8 @@
 <lb n="100198"/>tuae.</foreign></said></p>
 <p><lb n="100199"/>A flushed young man came from a gap of a hedge and after him came
 <lb n="100200"/>a young woman with wild nodding daisies in her hand. The young man
-<lb n="100201"/>raised his cap abruptly: the young woman abruptly bent and with slow care
-<lb n="100202"/>detached from her light skirt a clinging twig.</p>
+<lb n="100201"/>raised his cap abruptly: <ref xml:id="lb_100201">the young woman abruptly bent and with slow care
+<lb n="100202"/>detached from her light skirt a clinging twig.</ref></p>
 <p><lb n="100203"/>Father Conmee blessed both gravely and turned a thin page of his
 <lb n="100204"/>breviary. <foreign xml:lang="he">Sin</foreign>:
 <lb n="100205"/><said who="jc">―<foreign xml:lang="la">Principes persecuti sunt me gratis: et a verbis tuis formidavit cor meum.</foreign></said></p>
@@ -438,8 +438,8 @@
 <lb n="100437"/><said who="nl">―The reverend Hugh C. Love, Rathcoffey. Present address: Saint
 <lb n="100438"/>Michael's, Sallins. Nice young chap he is. He's writing a book about the
 <lb n="100439"/>Fitzgeralds he told me. He's well up in history, faith.</said></p>
-<p><lb n="100440"/>The young woman with slow care detached from her light skirt a
-<lb n="100441"/>clinging twig.
+<p><lb n="100440"/><ref xml:id="lb_100440">The young woman with slow care detached from her light skirt a
+<lb n="100441"/>clinging twig.</ref>
 <lb n="100442"/><said who="jjom">―I thought you were at a new gunpowder plot,</said> J. J. O'Molloy said.</p>
 <p><lb n="100443"/>Ned Lambert cracked his fingers in the air.
 <lb n="100444"/><said who="nl">―God!</said> he cried. <said who="nl">I forgot to tell him that one about the earl of Kildare after

--- a/u14_oxen.xml
+++ b/u14_oxen.xml
@@ -1156,8 +1156,8 @@
 <lb n="141155"/>He was walking by the hedge, reading, I think a brevier book with, I doubt
 <lb n="141156"/>not, a witty letter in it from Glycera or Chloe to keep the page. The sweet
 <lb n="141157"/>creature turned all colours in her confusion, feigning to reprove a slight
-<lb n="141158"/>disorder in her dress: a slip of underwood clung there for the very trees
-<lb n="141159"/>adore her. When Conmee had passed she glanced at her lovely echo in that
+<lb n="141158"/>disorder in her dress: <ref xml:id="lb_141158">a slip of underwood clung there for the very trees
+<lb n="141159"/>adore her.</ref> When Conmee had passed she glanced at her lovely echo in that
 <lb n="141160"/>little mirror she carries. But he had been kind. In going by he had blessed
 <lb n="141161"/>us. The gods too are ever kind, Lenehan said. If I had poor luck with Bass's
 <lb n="141162"/>mare perhaps this draught of his may serve me more propensely. He was

--- a/u17_ithaca.xml
+++ b/u17_ithaca.xml
@@ -230,8 +230,8 @@
 <p rend="non-indent"><lb n="170229"/>Having set the halffilled kettle on the now burning coals, why did he return
 <lb n="170230"/>to the stillflowing tap?</p>
 <p rend="non-indent"><lb n="170231"/>To wash his soiled hands with a partially consumed tablet of Barrington's
-<lb n="170232"/>lemonflavoured soap, to which paper still adhered, (bought thirteen hours
-<lb n="170233"/>previously for fourpence and still unpaid for), in fresh cold neverchanging
+<lb n="170232"/>lemonflavoured soap, to which paper still adhered, (<ref xml:id="lb_170232">bought thirteen hours
+<lb n="170233"/>previously for fourpence and still unpaid for</ref>), in fresh cold neverchanging
 <lb n="170234"/>everchanging water and dry them, face and hands, in a long redbordered
 <lb n="170235"/>holland cloth passed over a wooden revolving roller.</p>
 <p rend="non-indent"><lb n="170236"/>What reason did Stephen give for declining Bloom's offer?</p>


### PR DESCRIPTION
This adds a `cross-reference.xml` document, several <ref> tags,
and the very first example of a cross reference: "agenbite of inwit".

This follows the idea in #39, which adds `<ref>` tags in the text and
groups them using a `<link>` tag in `cross-references.xml`, with the 
suggestion in #42, of enumerating the `<ref>` tags using the nearest
`<lb>` tag.

Some additional "header"/padding tags may need to go in `cross-references.xml`, 
but for now it's just a sequence of `<link>` tags wrapped in a `<TEI>` tag.

This also demonstrates the addition of a `<note>` (with `target` attribute) 
to expand on and explain the cross-reference.